### PR TITLE
fix: Don’t show warnings about ignored files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "copy-tailwind-preset": "cp ./tailwind-preset-config-musketeers.js dist",
     "build-storybook": "build-storybook",
     "storybook": "start-storybook -p 6006",
-    "lint": "eslint src/components/**",
-    "lint:fix": "eslint src/components/** --fix"
+    "lint": "eslint src/components",
+    "lint:fix": "eslint src/components --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",


### PR DESCRIPTION
"Another way not to show that warning is to use dir names: eslint src instead of globbing patterns: eslint src/*."

"eslint src worked... But, i am curious how it is different than eslint src/**?"

"@mukesh210, the differene is that in the first example you are telling the eslint to lint the src directory so it lints it while skiping the ignored files. However if you call eslint src/** you are saying "lint every single file that matches this pattern". And since the ignored files match the pattern src/** you are literally telling the eslint to lint those ignored file so eslint warns you it cannot perform your request."

@deniaz FYI..